### PR TITLE
Dev

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -45,3 +45,8 @@ body {
 .main-content {
   margin: 0 80px;
 }
+
+
+@media screen and (max-width: 600px) {
+					.main-content {margin: 3%}
+}

--- a/css/index.css
+++ b/css/index.css
@@ -30,3 +30,8 @@ header, .experience {
 	border: 2px solid #E13A63;
 	padding: 10px;
 }
+
+@media screen and (max-width: 930px) {
+					.left	 {width: 63%}
+					.right {width: 80%}
+}

--- a/css/projects.css
+++ b/css/projects.css
@@ -1,13 +1,14 @@
 .screenshot {
-  padding-top:30px;
+  padding-top:5px;
   height: 200px;
-  width: 300px;
+  width: 250px;
 }
 
 .tile {
 	display: inline-block;
 	width: 30%;
-	margin-right: 3%;
+	margin-right: 1.5%;
+  margin-left: 1.5%;
 	margin-top: 25px;
 	text-align: center;
 	border: 2px solid #E13A63;
@@ -20,8 +21,8 @@
 }
 
 
-@media screen and (max-width: 600px) {
+@media screen and (max-width: 999px) {
 
+.tile {width: 85%}
 
-                
 }

--- a/css/projects.css
+++ b/css/projects.css
@@ -18,3 +18,10 @@
 	display: block;
 	margin: 0 auto;
 }
+
+
+@media screen and (max-width: 600px) {
+
+
+                
+}

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
   <link href="https://fonts.googleapis.com/css?family=Raleway" rel="stylesheet">
   <link rel="stylesheet" type="text/css" href="css/global.css">
   <link rel="stylesheet" type="text/css" href="css/index.css">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 </head>
 <body>
   <nav class="navbar">
@@ -36,7 +37,7 @@
         <img id="headshot" src="images/headshot.jpg">
       </div>
 
-      <div class="right">
+      <div>
         <h1>Stephen Reid</h1>
         <h2>Devops Engineer</h2>
 

--- a/projects.html
+++ b/projects.html
@@ -6,6 +6,7 @@
   <link rel="stylesheet" type="text/css" href="css/global.css">
   <link rel="stylesheet" type="text/css" href="css/projects.css">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon.png">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 </head>
 <body>
   <nav class="navbar">


### PR DESCRIPTION
Changes:
margining and padding on the index and project page have been set to be reduced when the page is smaller or viewed on a smartphone or tablet in order to save space and make use of as much screen space.

the image and text on the index page no longer over lap when making the page any smaller then 850px wide instead they will just neatly stack above one another.

On the Projects page the 3 projects are set to be viewed as 3 columns with content and an image however the screen size is often not be enough or can made them overlap which doesn't look well, to resolve this i used a media query in the project css file that set the column with the image and content to take up 85% of the screen in width individually if unable to display all three.

i then had a walkthrough of the website in both desktop and mobile, i believe my amendments improved the smart-device user experience substantially considering not changing the existing ccs or HTML.

Naseem   